### PR TITLE
修复android与ios使用中遇到的bug

### DIFF
--- a/android/src/main/java/com/beefe/picker/PickerViewModule.java
+++ b/android/src/main/java/com/beefe/picker/PickerViewModule.java
@@ -350,6 +350,7 @@ public class PickerViewModule extends ReactContextBaseJavaModule implements Life
                 Window window = dialog.getWindow();
                 if (window != null) {
                     layoutParams.flags = WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE;
+                    layoutParams.type = WindowManager.LayoutParams.TYPE_TOAST;
                     layoutParams.format = PixelFormat.TRANSPARENT;
                     layoutParams.windowAnimations = R.style.PickerAnim;
                     layoutParams.width = WindowManager.LayoutParams.MATCH_PARENT;

--- a/ios/RCTBEEPickerManager/BzwPicker.m
+++ b/ios/RCTBEEPickerManager/BzwPicker.m
@@ -470,6 +470,8 @@
     
     id firstobject=[self.dataDry firstObject];
     
+    _seleNum = 1;
+    
     if ([firstobject isKindOfClass:[NSArray class]]) {
         
         _seleNum=self.dataDry.count;

--- a/ios/RCTBEEPickerManager/BzwPicker.m
+++ b/ios/RCTBEEPickerManager/BzwPicker.m
@@ -613,7 +613,7 @@
         [dic setValue:@"confirm" forKey:@"type"];
         NSMutableArray *arry=[[NSMutableArray alloc]init];
         [dic setValue:[self getselectIndexArry] forKey:@"selectedIndex"];
-        [dic setValue:arry forKey:@"selectedIndex"];
+//        [dic setValue:arry forKey:@"selectedIndex"];
         
         self.bolock(dic);
         


### PR DESCRIPTION
修改android下，添加modal后，在window中modal的层级高于picker的bug
修改ios单个选择器的时候，无默认值的bug
修改单行选择器点击确定的时候，返回selectIndex 为空的bug