### PR TITLE
Fix type of selectedValue at README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 |pickerFontSize        |            |number  |16                 |
 |pickerFontColor       |            |array   |[31, 31, 31, 1]    |
 |pickerData            |            |array   |                   |
-|selectedValue         |            |string  |                   |
+|selectedValue         |            |array   |                   |
 |onPickerConfirm       |            |function|                   |
 |onPickerCancel        |            |function|                   |
 |onPickerSelect        |            |function|                   |


### PR DESCRIPTION
Hello there, thank you for this awesome react-native component.

I noticed that the README is saying that the type for the `selectedValue` prop is `string` but as examples shows it should be an `array`.