### PR TITLE
ios: do not show picker at the end of initialising

### DIFF
--- a/ios/RCTBEEPickerManager/RCTBEEPickerManager.m
+++ b/ios/RCTBEEPickerManager/RCTBEEPickerManager.m
@@ -83,13 +83,6 @@ RCT_EXPORT_METHOD(_init:(NSDictionary *)indic){
     dispatch_async(dispatch_get_main_queue(), ^{
         
         [self.window addSubview:_pick];
-        
-        [UIView animateWithDuration:.3 animations:^{
-            
-            [_pick setFrame:CGRectMake(0, SCREEN_HEIGHT-self.height, SCREEN_WIDTH, self.height)];
-            
-        }];
-        
     });
     
 }


### PR DESCRIPTION
On iOS, when calling `Picker.init()` it will show the picker immediately. This is not what I expected since I would call `Picker.init()` in the constructor. This PR fixes this.