### PR TITLE
Fixed selectedIndex value on iOS

### DIFF
--- a/ios/RCTBEEPickerManager/BzwPicker.m
+++ b/ios/RCTBEEPickerManager/BzwPicker.m
@@ -469,6 +469,8 @@
     self.dataDry=[self.pickerDic objectForKey:@"pickerData"];
     
     id firstobject=[self.dataDry firstObject];
+
+    _seleNum = 1; //Default value, data is a simple array
     
     if ([firstobject isKindOfClass:[NSArray class]]) {
         


### PR DESCRIPTION
`selectedIndex` value on iOS was empty if picker data was a simple array.