### PR TITLE
Fixes import of RCTBridgeModule.h for newer versions or React Native

### DIFF
--- a/ios/RCTBEEPickerManager/RCTBEEPickerManager.h
+++ b/ios/RCTBEEPickerManager/RCTBEEPickerManager.h
@@ -7,7 +7,12 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "RCTBridgeModule.h"
+
+#if __has_include(<React/RCTBridgeModule.h>)
+  #import <React/RCTBridgeModule.h>
+#else
+  #import "RCTBridgeModule.h"
+#endif
 
 @interface RCTBEEPickerManager : NSObject<RCTBridgeModule>
 


### PR DESCRIPTION
For newer versions of React Native (this change was tested on my project using `0.48.2`) we need the import statement to look like:

```objective-c
#import <React/RCTBridgeModule.h>
```

instead of:

```obj-c
#import "RCTBridgeModule.h"
```

This change should be backwards compatible since we're looking to see if `<React/RCTBridgeModule.h>` is available and if not, use the old import syntax.