### PR TITLE
expanded click area of cancel/pick buttons

### DIFF
--- a/ios/RCTBEEPickerManager/BzwPicker.m
+++ b/ios/RCTBEEPickerManager/BzwPicker.m
@@ -48,7 +48,8 @@
     [self addSubview:view];
     
     self.leftBtn = [UIButton buttonWithType:UIButtonTypeCustom];
-    self.leftBtn.frame = CGRectMake(10, 5, 90, 30);
+    self.leftBtn.frame = CGRectMake(0, 0, 90, 40);
+    [self.leftBtn setTitleEdgeInsets:UIEdgeInsetsMake(0, 10.0, 0, 0)];
     [self.leftBtn setTitle:self.leftStr forState:UIControlStateNormal];
     [self.leftBtn setFont:[UIFont systemFontOfSize:[_pickerToolBarFontSize integerValue]]];
     self.leftBtn.contentHorizontalAlignment = UIControlContentHorizontalAlignmentLeft;
@@ -61,7 +62,8 @@
     view.backgroundColor=[self colorWith:topbgColor];
     
     self.rightBtn = [UIButton buttonWithType:UIButtonTypeCustom];
-    self.rightBtn.frame = CGRectMake(view.frame.size.width-100,5, 90, 30);
+    self.rightBtn.frame = CGRectMake(view.frame.size.width-90,0, 90, 40);
+    [self.rightBtn setTitleEdgeInsets:UIEdgeInsetsMake(0, 0, 0, 10.0)];
     [self.rightBtn setTitle:self.rightStr forState:UIControlStateNormal];
     self.rightBtn.contentHorizontalAlignment=UIControlContentHorizontalAlignmentRight;
     


### PR DESCRIPTION
We had some customers having trouble with the click area of the buttons when using different kinds of iphone devices. This commit stretches the click area of the cancel and select buttons to take full height and all the way to their respective edge.