### PR TITLE
Fix ambiguous resolution with react-native module

### DIFF
--- a/Picker.podspec
+++ b/Picker.podspec
@@ -14,8 +14,6 @@ Pod::Spec.new do |s|
   s.platform       = :ios, '7.0'
   s.preserve_paths = '*.js'
 
-  s.dependency 'React'
-
   s.subspec 'Core' do |ss|
     ss.source_files = 'ios/RCTBEEPickerManager/*.{h,m}'
     ss.public_header_files = ['ios/RCTBEEPickerManager/*.h']


### PR DESCRIPTION
Fixes #251 

We're getting this issue when trying to run our app after installing this module:
![abc](https://user-images.githubusercontent.com/3298414/35079999-3112bdca-fc4e-11e7-9611-75c366b9b5ae.png)

I suspect React-native has since changed the way it installs the native `React-Native` dependencies so that `React` isn't needed in the Podspec anymore.

react-native-picker: 4.3.4
react-native: 0.52.0
react: 16.2.0
npm: 5.3.0
node: v8.5.0