### PR TITLE
Revert "Fix ambiguous resolution with react-native module (#266)"

### DIFF
--- a/Picker.podspec
+++ b/Picker.podspec
@@ -14,6 +14,8 @@ Pod::Spec.new do |s|
   s.platform       = :ios, '7.0'
   s.preserve_paths = '*.js'
 
+  s.dependency 'React'
+
   s.subspec 'Core' do |ss|
     ss.source_files = 'ios/RCTBEEPickerManager/*.{h,m}'
     ss.public_header_files = ['ios/RCTBEEPickerManager/*.h']


### PR DESCRIPTION
This reverts commit 6c0801000a0eec50d640c22216e3012da770ea77.

Turns out `s.dependency 'React'` wasn't the exact issue.

1. You have to point the `./ios/Podfile` to the React package in the `./node_modules/react-native` folder (0.52) instead of the published one on Cocoapods (0.11) (see [here](https://facebook.github.io/react-native/docs/integration-with-existing-apps.html)). I guess I forgot to configure this correctly from the start.
2. Add [this post-install line](https://github.com/rebeccahughes/react-native-device-info/issues/63#issuecomment-359524273) in the `Podfile` to remove conflicting references to React.
3. [Update to RN 0.53 to solve a compilation issue with the Yoga dependency.](https://github.com/facebook/react-native/issues/17274#issuecomment-360753081)