### PR TITLE
Fixes installation via cocoapods

### DIFF
--- a/Picker.podspec
+++ b/Picker.podspec
@@ -15,6 +15,7 @@ Pod::Spec.new do |s|
   s.preserve_paths = '*.js'
 
   s.subspec 'Core' do |ss|
+    ss.dependency 'React'
     ss.source_files = 'ios/RCTBEEPickerManager/*.{h,m}'
     ss.public_header_files = ['ios/RCTBEEPickerManager/*.h']
   end


### PR DESCRIPTION
This library was unable to be installed if react-native was installed via cocoapods, this was due to the following error:

`RCTBridgeModule.h not found`

This PR changes the podspec so that it correctly link the RN dependency.

Tested on RN 0.51.0 installed via cocoapods