### PR TITLE
True hide picker for IOS

### DIFF
--- a/ios/RCTBEEPickerManager/BzwPicker.m
+++ b/ios/RCTBEEPickerManager/BzwPicker.m
@@ -617,6 +617,8 @@
             
         }];
     });
+
+    self.pick.hidden=YES;
 }
 //按了确定按钮
 -(void)cfirmAction

--- a/ios/RCTBEEPickerManager/RCTBEEPickerManager.m
+++ b/ios/RCTBEEPickerManager/RCTBEEPickerManager.m
@@ -117,7 +117,11 @@ RCT_EXPORT_METHOD(hide){
                 [_pick setFrame:CGRectMake(0, SCREEN_HEIGHT, SCREEN_WIDTH, self.height)];
             }];
         });
-    }return;
+    }
+
+    self.pick.hidden=YES;
+
+	return;
 }
 
 RCT_EXPORT_METHOD(select: (NSArray*)data){


### PR DESCRIPTION
Micro fix:
Just added 'self.pick.hidden=YES;' in hide picker functions.
The picker will be really closed now, instead of just visually hidden by animation.

E.g: If you push the cancel button, and then you change orientation of device, you can see the 'hide' picker animation triggered again (very fastly)