### PR TITLE
Picker View Custom Height

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 |pickerFontSize        | number  | 16                 | iOS/Android  |   |
 |pickerFontColor       | array   | [31, 31, 31, 1]    | iOS/Android  |   |
 |pickerRowHeight       | number  | 24                 | iOS          |   |
+|pickerHeight          | number  | 250                | iOS          |   |
 |pickerData            | array   |                    | iOS/Android  |   |
 |selectedValue         | array   |                    | iOS/Android  |   |
 |onPickerConfirm       | function|                    | iOS/Android  |   |

--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ const options = {
     pickerRowHeight: 24,
     wheelFlex: [1, 1, 1],
     pickerData: [],
+    pickerHeight: 250,
     selectedValue: [],
     onPickerConfirm(){},
     onPickerCancel(){},

--- a/ios/RCTBEEPickerManager/RCTBEEPickerManager.m
+++ b/ios/RCTBEEPickerManager/RCTBEEPickerManager.m
@@ -54,6 +54,7 @@ RCT_EXPORT_METHOD(_init:(NSDictionary *)indic){
     NSArray *weightArry=indic[@"wheelFlex"];
     NSString *pickerToolBarFontSize=[NSString stringWithFormat:@"%@",indic[@"pickerToolBarFontSize"]];
     NSString *pickerFontSize=[NSString stringWithFormat:@"%@",indic[@"pickerFontSize"]];
+    NSString *pickerHeight=[NSString stringWithFormat:@"%@",indic[@"pickerHeight"]];
     NSArray *pickerFontColor=indic[@"pickerFontColor"];
     NSString *pickerRowHeight=indic[@"pickerRowHeight"];
     id pickerData=indic[@"pickerData"];
@@ -73,10 +74,14 @@ RCT_EXPORT_METHOD(_init:(NSDictionary *)indic){
 
     }];
 
-    if ([[UIDevice currentDevice].systemVersion doubleValue] >= 9.0 ) {
-        self.height=250;
-    }else{
-        self.height=220;
+    if(pickerHeight != nil && [pickerHeight floatValue] > 0) {
+        self.height = [pickerHeight floatValue]
+    } else {
+        if ([[UIDevice currentDevice].systemVersion doubleValue] >= 9.0 ) {
+            self.height=250;
+        }else{
+            self.height=220;
+        }
     }
     
     self.pick=[[BzwPicker alloc]initWithFrame:CGRectMake(0, SCREEN_HEIGHT, SCREEN_WIDTH, self.height) dic:dataDic leftStr:pickerCancelBtnText centerStr:pickerTitleText rightStr:pickerConfirmBtnText topbgColor:pickerToolBarBg bottombgColor:pickerBg leftbtnbgColor:pickerCancelBtnColor rightbtnbgColor:pickerConfirmBtnColor centerbtnColor:pickerTitleColor selectValueArry:selectArry weightArry:weightArry pickerToolBarFontSize:pickerToolBarFontSize pickerFontSize:pickerFontSize pickerFontColor:pickerFontColor  pickerRowHeight: pickerRowHeight];


### PR DESCRIPTION
Some pickers have fewer options than others (like a gender selector) so there is to much space wasted. This PR ensure that the react developer is the one who decides whether to use the default height or his own.