### PR TITLE
Make pickerCancelBtnText an optional for typed language.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -60,7 +60,7 @@ interface PickerOptions {
      * @type {string}
      * @memberof PickerOptions
      */
-    pickerCancelBtnText: string
+    pickerCancelBtnText?: string
 
     /**
      * The color of the text for the confirm button


### PR DESCRIPTION
Make `pickerCancelBtnText` an optional for typed language to remove misleading warning when not provide prop `pickerCancelBtnText`.