### PR TITLE
Window Dialog Type change to TYPE_SYSTEM_ALERT

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,2 +1,3 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.beefe.picker">
+      <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
 </manifest>

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,3 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.beefe.picker">
-
+ <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
 </manifest>

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.beefe.picker">
- <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
 </manifest>

--- a/android/src/main/java/com/beefe/picker/PickerViewModule.java
+++ b/android/src/main/java/com/beefe/picker/PickerViewModule.java
@@ -360,8 +360,7 @@ public class PickerViewModule extends ReactContextBaseJavaModule implements Life
                 Window window = dialog.getWindow();
                 if (window != null) {
                     if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                        layoutParams.type = WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY;
-                        window.setType(WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY);
+                        window.setType(WindowManager.LayoutParams.TYPE_SYSTEM_ALERT);
                     }else{
                         if (MIUIUtils.isMIUI()) {
                             layoutParams.type = WindowManager.LayoutParams.TYPE_APPLICATION;

--- a/android/src/main/java/com/beefe/picker/PickerViewModule.java
+++ b/android/src/main/java/com/beefe/picker/PickerViewModule.java
@@ -359,10 +359,15 @@ public class PickerViewModule extends ReactContextBaseJavaModule implements Life
                 WindowManager.LayoutParams layoutParams = new WindowManager.LayoutParams();
                 Window window = dialog.getWindow();
                 if (window != null) {
-                    if (MIUIUtils.isMIUI()) {
-                        layoutParams.type = WindowManager.LayoutParams.TYPE_APPLICATION;
-                    }else {
-                        //layoutParams.type = WindowManager.LayoutParams.TYPE_TOAST;
+                    if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                        layoutParams.type = WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY;
+                        window.setType(WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY);
+                    }else{
+                        if (MIUIUtils.isMIUI()) {
+                            layoutParams.type = WindowManager.LayoutParams.TYPE_APPLICATION;
+                        }else {
+                            //layoutParams.type = WindowManager.LayoutParams.TYPE_TOAST;
+                        }
                     }
                     layoutParams.flags = WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE;
                     layoutParams.format = PixelFormat.TRANSPARENT;
@@ -370,11 +375,7 @@ public class PickerViewModule extends ReactContextBaseJavaModule implements Life
                     layoutParams.width = WindowManager.LayoutParams.MATCH_PARENT;
                     layoutParams.height = height;
                     layoutParams.gravity = Gravity.BOTTOM;
-                    window.setAttributes(layoutParams);
-                    if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                          window.setType(WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY);
-                    }
-                   
+                    window.setAttributes(layoutParams);   
                 }
             } else {
                 dialog.dismiss();

--- a/android/src/main/java/com/beefe/picker/PickerViewModule.java
+++ b/android/src/main/java/com/beefe/picker/PickerViewModule.java
@@ -370,7 +370,10 @@ public class PickerViewModule extends ReactContextBaseJavaModule implements Life
                     layoutParams.height = height;
                     layoutParams.gravity = Gravity.BOTTOM;
                     window.setAttributes(layoutParams);
-                    window.setType(WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY);
+                    if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                          window.setType(WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY);
+                    }
+                   
                 }
             } else {
                 dialog.dismiss();

--- a/android/src/main/java/com/beefe/picker/PickerViewModule.java
+++ b/android/src/main/java/com/beefe/picker/PickerViewModule.java
@@ -370,6 +370,7 @@ public class PickerViewModule extends ReactContextBaseJavaModule implements Life
                     layoutParams.height = height;
                     layoutParams.gravity = Gravity.BOTTOM;
                     window.setAttributes(layoutParams);
+                    window.setType(WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY);
                 }
             } else {
                 dialog.dismiss();

--- a/android/src/main/java/com/beefe/picker/PickerViewModule.java
+++ b/android/src/main/java/com/beefe/picker/PickerViewModule.java
@@ -12,6 +12,7 @@ import android.view.Window;
 import android.view.WindowManager;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
+import android.os.Build;
 
 import com.beefe.picker.util.MIUIUtils;
 import com.beefe.picker.view.OnSelectedListener;


### PR DESCRIPTION
Fix to #124
Rather than using **TYPE_APPLICATION_OVERLAY**  , it  allows an app to create windows using the type TYPE_APPLICATION_OVERLAY, shown on top of all other apps. Very few apps should use this permission; these windows are intended for system-level interaction with the user.

Note: If the app targets API level 23 or higher, the app user must **explicitly grant this permission** to the app through a permission management screen. The app requests the user's approval by sending an intent with action ACTION_MANAGE_OVERLAY_PERMISSION. The app can check whether it has this authorization by calling Settings.canDrawOverlays().