### PR TITLE
Support PickerView height customization both for IOS and android

### DIFF
--- a/android/android.iml
+++ b/android/android.iml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module external.system.id="GRADLE" type="JAVA_MODULE" version="4">
+  <component name="FacetManager">
+    <facet type="android-gradle" name="Android-Gradle">
+      <configuration>
+        <option name="GRADLE_PROJECT_PATH" value=":" />
+      </configuration>
+    </facet>
+  </component>
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="jdk" jdkName="1.8" jdkType="JavaSDK" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/android/src/main/java/com/beefe/picker/PickerViewModule.java
+++ b/android/src/main/java/com/beefe/picker/PickerViewModule.java
@@ -110,6 +110,8 @@ public class PickerViewModule extends ReactContextBaseJavaModule implements Life
     private static final String PICKER_TEXT_SIZE = "pickerFontSize";
     private static final String PICKER_TEXT_ELLIPSIS_LEN = "pickerTextEllipsisLen";
 
+    private static final String PICKER_ITEMS_VISIBLE_COUNT = "androidItemsVisibleCount";
+
     private static final String PICKER_FONT_FAMILY = "pickerFontFamily";
 
     private static final String PICKER_EVENT_NAME = "pickerEvent";
@@ -300,6 +302,19 @@ public class PickerViewModule extends ReactContextBaseJavaModule implements Life
                 }
             }
 
+            int pickerVisibleItemsCount = 9;
+            if (options.hasKey(PICKER_ITEMS_VISIBLE_COUNT)) {
+                try {
+                    pickerVisibleItemsCount = options.getInt(PICKER_ITEMS_VISIBLE_COUNT);
+                } catch (Exception e) {
+                    pickerVisibleItemsCount = (int) options.getDouble(PICKER_ITEMS_VISIBLE_COUNT);
+                }
+
+                if(pickerVisibleItemsCount %2 ==0){
+                    pickerVisibleItemsCount++;
+                }
+            }
+
             ReadableArray pickerData = options.getArray(PICKER_DATA);
 
             int pickerViewHeight;
@@ -313,6 +328,7 @@ public class PickerViewModule extends ReactContextBaseJavaModule implements Life
                     pickerViewLinkage.setPickerData(pickerData, weights);
                     pickerViewLinkage.setTextColor(pickerTextColor);
                     pickerViewLinkage.setTextSize(pickerTextSize);
+                    pickerViewLinkage.setItemsVisibleCount(pickerVisibleItemsCount);
                     pickerViewLinkage.setTextEllipsisLen(pickerTextEllipsisLen);
                     pickerViewLinkage.setIsLoop(isLoop);
 
@@ -333,6 +349,7 @@ public class PickerViewModule extends ReactContextBaseJavaModule implements Life
                     pickerViewAlone.setPickerData(pickerData, weights);
                     pickerViewAlone.setTextColor(pickerTextColor);
                     pickerViewAlone.setTextSize(pickerTextSize);
+                    pickerViewAlone.setItemsVisibleCount(pickerVisibleItemsCount);
                     pickerViewAlone.setTextEllipsisLen(pickerTextEllipsisLen);
                     pickerViewAlone.setIsLoop(isLoop);
 

--- a/android/src/main/java/com/beefe/picker/view/LoopView.java
+++ b/android/src/main/java/com/beefe/picker/view/LoopView.java
@@ -269,6 +269,12 @@ public class LoopView extends View {
         invalidate();
     }
 
+    public final void setItemsVisibleCount(int itemsVisibleCount){
+        this.itemsVisible=itemsVisibleCount;
+        remeasure();
+        invalidate();
+    }
+
     public String getIndexItem(int index) {
         return items.get(index);
     }

--- a/android/src/main/java/com/beefe/picker/view/PickerViewAlone.java
+++ b/android/src/main/java/com/beefe/picker/view/PickerViewAlone.java
@@ -213,6 +213,17 @@ public class PickerViewAlone extends LinearLayout {
         }
     }
 
+    public void setItemsVisibleCount(int count){
+        int viewCount = pickerViewAloneLayout.getChildCount();
+        for (int i = 0; i < viewCount; i++) {
+            View view = pickerViewAloneLayout.getChildAt(i);
+            if (view instanceof LoopView) {
+                LoopView loopView = (LoopView) view;
+                loopView.setItemsVisibleCount(count);
+            }
+        }
+    }
+
     public void setTypeface(Typeface typeface){
         int viewCount = pickerViewAloneLayout.getChildCount();
         for (int i = 0; i < viewCount; i++) {

--- a/android/src/main/java/com/beefe/picker/view/PickerViewLinkage.java
+++ b/android/src/main/java/com/beefe/picker/view/PickerViewLinkage.java
@@ -604,6 +604,20 @@ public class PickerViewLinkage extends LinearLayout {
         }
     }
 
+    public void setItemsVisibleCount(int count){
+        switch (curRow) {
+            case 2:
+                loopViewOne.setItemsVisibleCount(count);
+                loopViewTwo.setItemsVisibleCount(count);
+                break;
+            case 3:
+                loopViewOne.setItemsVisibleCount(count);
+                loopViewTwo.setItemsVisibleCount(count);
+                loopViewThree.setItemsVisibleCount(count);
+                break;
+        }
+    }
+
     public void setTypeface(Typeface typeface){
         switch (curRow) {
             case 2:

--- a/index.d.ts
+++ b/index.d.ts
@@ -267,4 +267,24 @@ export default class Picker {
      * @memberof Picker
      */
     static isPickerShow(fn?: (err: any, message: any) => void): boolean
+
+    /**
+     * Row height of the ios picker view, ios and android are different
+     *
+     * Default is 250
+     *
+     * @type {number}
+     * @memberof PickerOptions
+     */
+    iosPickerHeight?: number
+
+    /**
+     * Max items of the picker can display (Workaround for set the picker view height on android)
+     *
+     * Default is 9
+     *
+     * @type {number}
+     * @memberof PickerOptions
+     */
+    androidItemsVisibleCount?: number
 }

--- a/index.js
+++ b/index.js
@@ -27,7 +27,9 @@ const options = {
     onPickerSelect(){},
     pickerToolBarFontSize: 16,
     pickerFontSize: 16,
-    pickerFontColor: [31, 31 ,31, 1]
+    pickerFontColor: [31, 31 ,31, 1],
+    iosPickerHeight: 250,
+    androidItemsVisibleCount: 9
 };
 
 export default {

--- a/ios/RCTBEEPickerManager/RCTBEEPickerManager.m
+++ b/ios/RCTBEEPickerManager/RCTBEEPickerManager.m
@@ -57,6 +57,7 @@ RCT_EXPORT_METHOD(_init:(NSDictionary *)indic){
     NSString *pickerFontFamily=[NSString stringWithFormat:@"%@",indic[@"pickerFontFamily"]];
     NSArray *pickerFontColor=indic[@"pickerFontColor"];
     NSString *pickerRowHeight=indic[@"pickerRowHeight"];
+    NSString *pickerHeight=indic[@"iosPickerHeight"];
     id pickerData=indic[@"pickerData"];
 
     NSMutableDictionary *dataDic=[[NSMutableDictionary alloc]init];
@@ -75,7 +76,7 @@ RCT_EXPORT_METHOD(_init:(NSDictionary *)indic){
     }];
 
     if ([[UIDevice currentDevice].systemVersion doubleValue] >= 9.0 ) {
-        self.height=250;
+        self.height=[pickerHeight integerValue];
     }else{
         self.height=220;
     }


### PR DESCRIPTION
For IOS, just set the option value: iosPickerHeight, default value is 250.
For Android, set the option value: androidItemsVisibleCount, default value is 9.