### PR TITLE
iOS：统一picker隐藏的动画时间为0.3s；修复隐藏picker时没有动画效果的问题

### DIFF
--- a/ios/RCTBEEPickerManager/BzwPicker.m
+++ b/ios/RCTBEEPickerManager/BzwPicker.m
@@ -601,14 +601,16 @@
     
     
     dispatch_async(dispatch_get_main_queue(), ^{
-        [UIView animateWithDuration:.2f animations:^{
+        [UIView animateWithDuration:.3f animations:^{
             
             [self setFrame:CGRectMake(0, SCREEN_HEIGHT, SCREEN_WIDTH, 250)];
             
         }];
     });
 
-    self.pick.hidden=YES;
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.3 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        self.pick.hidden=YES;
+    });
 }
 //按了确定按钮
 -(void)cfirmAction

--- a/ios/RCTBEEPickerManager/RCTBEEPickerManager.m
+++ b/ios/RCTBEEPickerManager/RCTBEEPickerManager.m
@@ -120,7 +120,9 @@ RCT_EXPORT_METHOD(hide){
         });
     }
 
-    self.pick.hidden=YES;
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.3 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        self.pick.hidden=YES;
+    });
 
     return;
 }


### PR DESCRIPTION
在iOS端，点击toolbar上的取消按钮时，toolbar以动画形式消失，但是picker直接消失，问题在于执行动画前已经执行了 self.picker.hidden = true; 解决方法就是延迟picker的隐藏