### PR TITLE
chore: 🤖 插件android端compileSdkVersion与buildToolsVersion读取项目值

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,8 +1,12 @@
 apply plugin: 'com.android.library'
 
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 android {
-    compileSdkVersion 27
-    buildToolsVersion "23.0.1"
+    compileSdkVersion safeExtGet('compileSdkVersion', 27)
+    buildToolsVersion safeExtGet('buildToolsVersion', '23.0.1')
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
compileSdkVersion、buildToolsVersion默认读取使用该库的项目版本，否则使用写死的值
