### PR TITLE
update

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 27
-    buildToolsVersion "23.0.1"
+    compileSdkVersion 28
+    buildToolsVersion "28.0.3"
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
compileSdkVersion -> 28
buildToolsVersion -> 28.03
The SDK version update resolves the issue of a packing error on RN0.62.2